### PR TITLE
Rehabilitated button to Login through page locally

### DIFF
--- a/src/app/ForgotPassword.js
+++ b/src/app/ForgotPassword.js
@@ -1,32 +1,32 @@
 import React, { useState } from 'react';
-import ForgotPasswordPage from './NewPassword';
+import ResetPasswordPage from './NewPassword';
 
 
 function ForgotPassword() {
     const [email, setEmail] = useState('');
-    const [isShowForgotPassword, setShowForgotPassword] = useState(true);
     const [isShowResetPassword, setShowResetPassword] = useState(false);
 
     const handleResetPasswordClick = () => {
-        setShowForgotPassword(false);
         setShowResetPassword(true)
     };
 
-    return (isShowForgotPassword ? (
-        <div className="flex flex-col items-center h-screen">
-            <h2 className="text-2xl font-semibold mb-3">Forgot Password</h2>
-            <div className="flex flex-col gap-4">
-                <div>
-                    <label className="block">Email:</label>
-                    <input type="text" value={email} onChange={(e) => setEmail(e.target.value)} className="border px-3 py-1 rounded text-black" />
+    if (isShowResetPassword) {
+        return (<ResetPasswordPage />)
+    }
+    else {
+        return (
+            <div className="flex flex-col items-center h-screen mx-4 sm:mx-auto sm:w-full md:w-2/3 lg:w-1/2">
+                <h2 className="text-2xl font-semibold mb-3">Forgot Password</h2>
+                <div className="flex flex-col gap-4 w-full">
+                    <div>
+                        <label className="block">Email:</label>
+                        <input type="text" value={email} onChange={(e) => setEmail(e.target.value)} className="border px-3 py-1 rounded text-black w-full" />
+                    </div>
                 </div>
+                <button onClick={handleResetPasswordClick} className="bg-green-500 text-white px-4 py-2 rounded mt-3">Reset Password</button>
             </div>
-            <button onClick={handleResetPasswordClick} className="bg-green-500 text-white px-4 py-2 rounded mt-3">Reset Password</button>
-        </div>
-    ) : (
-        isShowResetPassword && <ForgotPasswordPage/>
-    )
-    );
+        );
+    }
 }
 
 export default ForgotPassword;

--- a/src/app/LocalLoginPage.js
+++ b/src/app/LocalLoginPage.js
@@ -7,7 +7,6 @@ function LocalLoginPage({ onLogin }) {
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
     const [isForgotPassword, setShowForgotPassword] = useState(false); // New state for rendering ForgotPassword
-    const [isLoginPage, setLoginPage] = useState(true);
 
     const handleLogin = () => {
         // Other login logic, for now, just the email
@@ -20,10 +19,13 @@ function LocalLoginPage({ onLogin }) {
 
     const handleForgotPasswordClick = () => {
         setShowForgotPassword(true);
-        setLoginPage(false);
     };
 
-    return (isLoginPage ? (
+    if (isForgotPassword) {
+        return (<ForgotPassword/>)
+    }
+    else {
+    return (
         <div className="flex flex-col items-center h-screen mx-4 sm:mx-auto sm:w-full md:w-2/3 lg:w-1/2">
             <h2 className="text-2xl font-semibold mb-3">Login Page</h2>
             <div className="flex flex-col gap-4 w-full">
@@ -45,10 +47,8 @@ function LocalLoginPage({ onLogin }) {
                 No account? <button className="underline" onClick={() => console.log("Create an account")}>Create One</button>
             </div>
         </div>
-    ) : (
-        isForgotPassword && <ForgotPassword/>
-    )
     );
+    }
 }
 
 export default LocalLoginPage;

--- a/src/app/LocalLoginPage.js
+++ b/src/app/LocalLoginPage.js
@@ -1,0 +1,54 @@
+import React, { useState, useContext } from 'react';
+import ForgotPassword from './ForgotPassword';
+
+
+function LocalLoginPage({ onLogin }) {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const [isForgotPassword, setShowForgotPassword] = useState(false); // New state for rendering ForgotPassword
+    const [isLoginPage, setLoginPage] = useState(true);
+
+    const handleLogin = () => {
+        // Other login logic, for now, just the email
+        onLogin(email);
+    };
+
+    const toggleShowPassword = () => {
+        setShowPassword(!showPassword);
+    };
+
+    const handleForgotPasswordClick = () => {
+        setShowForgotPassword(true);
+        setLoginPage(false);
+    };
+
+    return (isLoginPage ? (
+        <div className="flex flex-col items-center h-screen mx-4 sm:mx-auto sm:w-full md:w-2/3 lg:w-1/2">
+            <h2 className="text-2xl font-semibold mb-3">Login Page</h2>
+            <div className="flex flex-col gap-4 w-full">
+                <div>
+                    <label className="block">Email:</label>
+                    <input type="text" value={email} onChange={(e) => setEmail(e.target.value)} className="border px-3 py-1 rounded text-black w-full" />
+                </div>
+                <div>
+                    <label className="block">Password:</label>
+                    <div className="relative">
+                        <input type={showPassword ? 'text' : 'password'} value={password} onChange={(e) => setPassword(e.target.value)} className="border px-3 py-1 rounded text-black w-full" />
+                        <button className="absolute top-1/2 right-2 transform -translate-y-1/2 text-black" onClick={toggleShowPassword}>{showPassword ? 'Hide' : 'Show'}</button>
+                    </div>
+                    <button className="text-white underline mt-2" onClick={handleForgotPasswordClick}>Forgot Password?</button>
+                </div>
+                <button onClick={handleLogin} className="bg-green-500 text-white px-4 py-2 rounded mt-3">Login</button>
+            </div>
+            <div className="mt-3 text-white">
+                No account? <button className="underline" onClick={() => console.log("Create an account")}>Create One</button>
+            </div>
+        </div>
+    ) : (
+        isForgotPassword && <ForgotPassword/>
+    )
+    );
+}
+
+export default LocalLoginPage;

--- a/src/app/LoginPage.js
+++ b/src/app/LoginPage.js
@@ -1,9 +1,18 @@
 import React, { useState, useContext } from 'react';
 import { authContext } from './auth-context';
+import LocalLoginPage from './LocalLoginPage';
 
 function LoginPage() {
     const { googleLoginHandler, facebookLoginHandler } = useContext(authContext);
+    const [isLocalLogin, setLocalLogin] = useState(false); // State for login through page
+    const handlePageLoginClick = () => {
+        setLocalLogin(true);
+    }
 
+    if (isLocalLogin) {
+        return (<LocalLoginPage/>)
+    }
+    else {
     return (
         <>
             <div className="h-dvh flex flex-col items-center justify-centerh-screen mt-3">
@@ -14,64 +23,16 @@ function LoginPage() {
                 <button onClick={facebookLoginHandler} className='flex self-start gap-2 p-4 mx-auto mt-6 font-medium text-white align-middle bg-gray-700 rounded-full'>
                     Facebook
                 </button> {/* FIXME */}
+                <button onClick={handlePageLoginClick} className='flex self-start gap-2 p-4 mx-auto mt-6 font-medium text-white align-middle bg-gray-700 rounded-full'>
+                    Log in & Sign Up Through Page
+                </button>
             </div>
             
         
         </>
     )
     }
+    }
         
-// import React, { useState } from 'react';
-// import ForgotPasswordPage from './NewPassword';
-// import ForgotPassword from './ForgotPassword';
-
-// function LoginPage({ onLogin }) {
-//     const [email, setEmail] = useState('');
-//     const [password, setPassword] = useState('');
-//     const [showPassword, setShowPassword] = useState(false);
-//     const [isForgotPassword, setShowForgotPassword] = useState(false); // New state for rendering ForgotPassword
-//     const [isLoginPage, setLoginPage] = useState(true);
-
-//     const handleLogin = () => {
-//         // Other login logic, for now, just the email
-//         onLogin(email);
-//     };
-
-//     const toggleShowPassword = () => {
-//         setShowPassword(!showPassword);
-//     };
-
-//     const handleForgotPasswordClick = () => {
-//         setShowForgotPassword(true);
-//         setLoginPage(false);
-//     };
-
-//     return (isLoginPage ? (
-//         <div className="flex flex-col items-center h-screen">
-//             <h2 className="text-2xl font-semibold mb-3">Login Page</h2>
-//             <div className="flex flex-col gap-4">
-//                 <div>
-//                     <label className="block">Email:</label>
-//                     <input type="text" value={email} onChange={(e) => setEmail(e.target.value)} className="border px-3 py-1 rounded text-black" />
-//                 </div>
-//                 <div>
-//                     <label className="block">Password:</label>
-//                     <div className="relative">
-//                         <input type={showPassword ? 'text' : 'password'} value={password} onChange={(e) => setPassword(e.target.value)} className="border px-3 py-1 rounded text-black" />
-//                         <button className="absolute top-1/2 right-2 transform -translate-y-1/2 text-black" onClick={toggleShowPassword}>{showPassword ? 'Hide' : 'Show'}</button>
-//                     </div>
-//                     <button className="text-white underline mt-2" onClick={handleForgotPasswordClick}>Forgot Password?</button>
-//                 </div>
-//                 <button onClick={handleLogin} className="bg-green-500 text-white px-4 py-2 rounded mt-3">Login</button>
-//             </div>
-//             <div className="mt-3 text-white">
-//                 No account? <button className="underline" onClick={() => console.log("Create an account")}>Create One</button>
-//             </div>
-//         </div>
-//     ) : (
-//         isForgotPassword && <ForgotPassword/>
-//     )
-//     );
-// }
 
 export default LoginPage;

--- a/src/app/NewPassword.js
+++ b/src/app/NewPassword.js
@@ -18,26 +18,27 @@ function ForgotPasswordPage({ onReturnHome }) {
     if(passwordChanged){
         return <PwdChangePage onReturnHome={onReturnHome} />;
     }
-
+    else {
     return (
-        <div className="flex flex-col items-center h-screen">
+        <div className="flex flex-col items-center h-screen mx-4 sm:mx-auto sm:w-full md:w-2/3 lg:w-1/2">
             <h2 className="text-2xl font-semibold mb-3">Forgot Password Page</h2>
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4 w-full">
                 <div>
                     <label className="block">Enter New Password:</label>
                     <div className="relative">
-                        <input type={showPassword ? 'text' : 'password'} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="border px-3 py-1 rounded text-black" />
+                        <input type={showPassword ? 'text' : 'password'} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="border px-3 py-1 rounded text-black w-full" />
                         <button className="absolute top-1/2 right-2 transform -translate-y-1/2 text-black" onClick={toggleShowPassword}>{showPassword ? 'Hide' : 'Show'}</button>
                     </div>
                 </div>
                 <div>
                     <label className="block">Confirm New Password:</label>
-                    <input type="password" value={confirmNewPassword} onChange={(e) => setConfirmNewPassword(e.target.value)} className="border px-3 py-1 rounded text-black" />
+                    <input type="password" value={confirmNewPassword} onChange={(e) => setConfirmNewPassword(e.target.value)} className="border px-3 py-1 rounded text-black w-full" />
                 </div>
             </div>
             <button onClick={handleConfirmPasswordChange} className="bg-green-500 text-white px-4 py-2 rounded mt-3">Confirm Password Change</button>
         </div>
     );
+    }
 }
 
 export default ForgotPasswordPage;


### PR DESCRIPTION
Rehabilitated a button that leads to a local Login (with forgot password and account creation). The Google and Facebook buttons are still present but now the user has a new option to log in with a new local account.