### PR TITLE
259 save monthly budget for different months

### DIFF
--- a/src/app/Finance-Context/finance-context.js
+++ b/src/app/Finance-Context/finance-context.js
@@ -71,13 +71,12 @@ export default function FinanceContextProvider({ children }) {
         budgets: items,
       });
 
-      setBudgets( 
-        {
+      setBudgets({
           id: docSnap.id,
           uid : user.uid,
           budgets : items,
-        }
-      )
+        })
+
     } catch (err) {
       throw err; 
     }
@@ -94,15 +93,15 @@ export default function FinanceContextProvider({ children }) {
       const q = query(colRef, where("uid", "==", user.uid));
       const docSnap = await getDocs(q);
       const updatedItems = docSnap.docs[0].data().budgets;
-      console.log(updatedItems);
       updatedItems[month] = newBudget;
       const budgetId = docSnap.docs[0].id;
       const docRef = doc(db, "monthly_budget", budgetId);
       await updateDoc(docRef, { budgets: updatedItems });
-      setBudgets((prevBudget) => ({
-        ...prevBudget,
-        budgets : updatedItems
-      }));
+      setBudgets({
+        id: budgetId,
+        uid: user.uid,
+        budgets: updatedItems
+      });
     } catch (err) {
       throw err;
     }
@@ -301,14 +300,14 @@ export default function FinanceContextProvider({ children }) {
       const colRef = collection(db, "monthly_budget");
       const q = query(colRef, where("uid", "==", user.uid));
       const docSnap = await getDocs(q);
-      const data = docSnap.docs.map((doc) => {
-        return {
-          id: doc.id,
-          ...doc.data(),
-          budgets: doc.data().budgets.map((item) => ({ ...item,}))
-        };
+      const items = docSnap.size > 0 ? docSnap.docs[0].data().budgets : [];
+      const docID = docSnap.size > 0 ? docSnap.docs[0].id : "";
+      
+      setBudgets({
+        id: docID,
+        uid: user.uid,
+        budgets: items
       });
-      setBudgets(data);
     }
 
     const getExpensesData = async () => {

--- a/src/app/Finance-Context/finance-context.js
+++ b/src/app/Finance-Context/finance-context.js
@@ -20,9 +20,9 @@ import {
 export const financeContext = createContext({
   income: [],
   expenses: [],
-  monthlyBudget: [],
-  addMonthlyBudget: async () => {},
-  updateMonthlyBudget: async () => {},
+  monthlyBudgets: [],
+  createMonthlyBudgets: async () => {},
+  updateMonthlyBudgets: async () => {},
   deleteBudget: async () => {},
   checkBudgetDuplication: async () => {},
   addIncomeItem: async () => {},
@@ -53,7 +53,7 @@ export const financeContext = createContext({
 export default function FinanceContextProvider({ children }) {
   const [income, setIncome] = useState([]);
   const [expenses, setExpenses] = useState([]);
-  const [monthlyBudget, setBudget] = useState([]);
+  const [monthlyBudgets, setBudgets] = useState([]);
 
   const { user } = useContext(authContext);
 
@@ -61,23 +61,23 @@ export default function FinanceContextProvider({ children }) {
    * 
    * @param {integer} newBudget - The budget to be added to the database.
    */
-  const addMonthlyBudget = async (newBudget) => {
+  const createMonthlyBudgets = async (newBudget, month) => {
     try {
       const collectionRef = collection(db, "monthly_budget");
+      const items = Array.from({ length: 12 }, () => 0); 
+      items[month] = newBudget;
       const docSnap = await addDoc(collectionRef, {
         uid : user.uid,
-        budget : newBudget
+        budgets: items,
       });
 
-      setBudget((newBudget) => {
-        return {
+      setBudgets( 
+        {
           id: docSnap.id,
           uid : user.uid,
-          budget : newBudget,
+          budgets : items,
         }
-      })
-
-      await checkBudgetDuplication();
+      )
     } catch (err) {
       throw err; 
     }
@@ -88,23 +88,21 @@ export default function FinanceContextProvider({ children }) {
    * 
    * @param {integer} newBudget - The new budget to update to the database.
    */
-  const updateMonthlyBudget = async (newBudget) => {
+  const updateMonthlyBudgets = async (newBudget, month) => {
     try {
       const colRef = collection(db, "monthly_budget");
       const q = query(colRef, where("uid", "==", user.uid));
       const docSnap = await getDocs(q);
-      if (docSnap.size === 0) {
-        await addMonthlyBudget(newBudget);
-      } else {
-        const budgetId = docSnap.docs[0].id;
-        const docRef = doc(db, "monthly_budget", budgetId);
-        await updateDoc(docRef, { budget: newBudget });
-        setBudget((prevBudget) => ({
-          ...prevBudget,
-          budget : newBudget
-        }));
-        await checkBudgetDuplication();
-      } 
+      const updatedItems = docSnap.docs[0].data().budgets;
+      console.log(updatedItems);
+      updatedItems[month] = newBudget;
+      const budgetId = docSnap.docs[0].id;
+      const docRef = doc(db, "monthly_budget", budgetId);
+      await updateDoc(docRef, { budgets: updatedItems });
+      setBudgets((prevBudget) => ({
+        ...prevBudget,
+        budgets : updatedItems
+      }));
     } catch (err) {
       throw err;
     }
@@ -266,9 +264,9 @@ export default function FinanceContextProvider({ children }) {
   const values = {
     income,
     expenses,
-    monthlyBudget,
-    addMonthlyBudget,
-    updateMonthlyBudget,
+    monthlyBudgets,
+    createMonthlyBudgets,
+    updateMonthlyBudgets,
     deleteBudget,
     checkBudgetDuplication,
     addIncomeItem,
@@ -305,12 +303,12 @@ export default function FinanceContextProvider({ children }) {
       const docSnap = await getDocs(q);
       const data = docSnap.docs.map((doc) => {
         return {
-         id : doc.id,
-         user : user.uid,
-         ...doc.data(), 
-        }
+          id: doc.id,
+          ...doc.data(),
+          budgets: doc.data().budgets.map((item) => ({ ...item,}))
+        };
       });
-      setBudget(data);
+      setBudgets(data);
     }
 
     const getExpensesData = async () => {

--- a/src/app/Page-Functionality/Calendar.css
+++ b/src/app/Page-Functionality/Calendar.css
@@ -116,3 +116,18 @@
     flex: 2;
     margin-top: 20px;
 }
+
+.budget-button {
+    display: block;
+    width: 300px;
+    text-align: center;
+    justify-content: center;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: rgb(150,150,150);
+    color: black;
+    border-radius: 10px;
+    padding: 10px 20px;
+  }

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -80,7 +80,7 @@ const Calendar = () => {
             if (!isNaN(budget)) {
                 if (monthlyBudgets.budgets.length === 0) {
                     createMonthlyBudgets(budget, currentMonth); 
-                    toast.success('Budget for' + months[currentMonth] + 'added successfully.')
+                    toast.success('Budget for ' + months[currentMonth] + ' added successfully.')
                 } else {
                     updateMonthlyBudgets(budget, currentMonth); 
                     monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ' + months[currentMonth] + ' updated successfully.') :  toast.success('Budget for ' + months[currentMonth] + ' added successfully.');

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -78,7 +78,7 @@ const Calendar = () => {
         if (input !== null) {
             const budget = parseFloat(input);
             if (!isNaN(budget)) {
-                if (monthlyBudgets.budgets.length < 0) {
+                if (monthlyBudgets.budgets.length === 0) {
                     createMonthlyBudgets(budget, currentMonth); 
                     toast.success('Budget for' + months[currentMonth] + 'added successfully.')
                 } else {

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useContext } from 'react';
+import React, { useEffect, useRef, useState, useContext, createContext } from 'react';
 import monthlyExpensefilter , { monthlyIncomeFilter } from './Filters/moneyFilters';
 import { financeContext } from '../Finance-Context/finance-context';
 import * as d3 from 'd3';
@@ -31,6 +31,7 @@ const Calendar = () => {
     const [showMonthSelectorPanel, setShowMonthSelectorPanel] = useState(false);
     const [shouldRenderCalendar, setShouldRenderCalendar] = useState(true);
 
+    debugger;
     //Variables to calculate total income, total expenses, and the percentage of the total expenses compared to the monthly budget.
     useEffect(() => {
         const monthlyincome = monthlyIncomeFilter(income, currentTime.getMonth() + 1, currentTime.getFullYear());
@@ -43,13 +44,21 @@ const Calendar = () => {
         }, 0);
         const totalIncome = monthlyincome.reduce((total, item) => total + item.amount, 0);
         let monthlyBudgetAmount = 1;
-    if(monthlyBudgets.length > 0) {
-        if(monthlyBudgets[0].budgets[currentMonth] !== 0) monthlyBudgetAmount = monthlyBudgets[0].budgets[currentMonth];
-    }
+        if(monthlyBudgets.length > 0) {
+            if(monthlyBudgets[0].budgets[currentMonth] !== 0) monthlyBudgetAmount = monthlyBudgets[0].budgets[currentMonth];
+        }
         let progressValue = (totalExpenses / monthlyBudgetAmount) * 100;
         progressValue > 100 ? progressValue = 100 : progressValue = progressValue;
         setProgress(progressValue);
     },[currentTime, submittedData, currentMonth, monthlyBudgets, income, expenses]);
+
+    const renderBudgetButton = () => {
+        return (
+        <div className='budget-button'>
+            <button onClick={handleAddOrUpdateBudget}>Add/Update Monthly Budget</button>
+        </div>
+        );
+    }
 
     function renderProgressBar(percentage){
         return (
@@ -456,6 +465,7 @@ const Calendar = () => {
 
     return (
         <div>
+            {renderBudgetButton()}
             <div className='month-selector-panel'>
                 {renderMonthSelector()}
             </div>

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useContext, createContext } from 'react';
 import monthlyExpensefilter , { monthlyIncomeFilter } from './Filters/moneyFilters';
 import { financeContext } from '../Finance-Context/finance-context';
+import { toast } from 'react-toastify';
 import * as d3 from 'd3';
 import './Calendar.css';
 
@@ -34,8 +35,9 @@ const Calendar = () => {
     debugger;
     //Variables to calculate total income, total expenses, and the percentage of the total expenses compared to the monthly budget.
     useEffect(() => {
-        const monthlyincome = monthlyIncomeFilter(income, currentTime.getMonth() + 1, currentTime.getFullYear());
-        const monthlyexpenses = monthlyExpensefilter(expenses, currentTime.getMonth() + 1, currentTime.getFullYear());
+        debugger;
+        const monthlyincome = monthlyIncomeFilter(income, currentMonth + 1, currentTime.getFullYear());
+        const monthlyexpenses = monthlyExpensefilter(expenses, currentMonth + 1, currentTime.getFullYear());
         const totalExpenses = monthlyexpenses.reduce((total, category) => {
         const categoryTotal = category.items.reduce((itemTotal, item) => {
             return itemTotal + item.amount;
@@ -44,8 +46,8 @@ const Calendar = () => {
         }, 0);
         const totalIncome = monthlyincome.reduce((total, item) => total + item.amount, 0);
         let monthlyBudgetAmount = 1;
-        if(monthlyBudgets.length > 0) {
-            if(monthlyBudgets[0].budgets[currentMonth] !== 0) monthlyBudgetAmount = monthlyBudgets[0].budgets[currentMonth];
+        if(monthlyBudgets && monthlyBudgets.budgets && monthlyBudgets.budgets.length > 0) {
+            if(monthlyBudgets.budgets[currentMonth] !== 0) monthlyBudgetAmount = monthlyBudgets.budgets[currentMonth];
         }
         let progressValue = (totalExpenses / monthlyBudgetAmount) * 100;
         progressValue > 100 ? progressValue = 100 : progressValue = progressValue;
@@ -79,10 +81,10 @@ const Calendar = () => {
             if (!isNaN(budget)) {
                 if (monthlyBudgets.length < 1) {
                     createMonthlyBudgets(budget, currentMonth); 
-                    toast.success('Budget for ${currentMonth} added successfully.')
+                    toast.success('Budget for' + currentMonth.toLocaleString() + 'added successfully.')
                 } else {
                     updateMonthlyBudgets(budget, currentMonth); 
-                    monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ${currentMonth} updated successfully.') :  toast.success('Budget for ${currentMonth} added successfully.');
+                    monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ' + currentMonth.toLocaleString() + ' updated successfully.') :  toast.success('Budget for ' + currentMonth.toLocaleString() + ' added successfully.');
 
                 }
             } else {

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -7,7 +7,7 @@ import './Calendar.css';
 
 const Calendar = () => {
     const svgRef = useRef(null);
-    const {expenses, income, monthlyBudget, addMonthlyBudget, updateMonthlyBudget} = useContext(financeContext);
+    const {expenses, income, monthlyBudgets, createMonthlyBudgets, updateMonthlyBudgets} = useContext(financeContext);
     const [currentTime, setCurrentTime] = useState(new Date());
     const [currentMonth, setCurrentMonth] = useState(new Date().getMonth());
     /* 
@@ -33,8 +33,8 @@ const Calendar = () => {
 
     debugger;
     //Variables to calculate total income, total expenses, and the percentage of the total expenses compared to the monthly budget.
-    const monthlyincome = monthlyIncomeFilter(income, currentTime.getMonth() + 1, currentTime.getFullYear());
-    const monthlyexpenses = monthlyExpensefilter(expenses, currentTime.getMonth() + 1, currentTime.getFullYear());
+    const monthlyincome = monthlyIncomeFilter(income, currentMonth + 1, currentTime.getFullYear());
+    const monthlyexpenses = monthlyExpensefilter(expenses, currentMonth + 1, currentTime.getFullYear());
     const totalExpenses = monthlyexpenses.reduce((total, category) => {
         const categoryTotal = category.items.reduce((itemTotal, item) => {
             return itemTotal + item.amount;
@@ -42,7 +42,10 @@ const Calendar = () => {
         return total + categoryTotal;
     }, 0);
     const totalIncome = monthlyincome.reduce((total, item) => total + item.amount, 0);
-    const monthlyBudgetAmount = monthlyBudget.length > 0 ? monthlyBudget[0].budget : 1;
+    let monthlyBudgetAmount = 1;
+    if(monthlyBudgets.length > 0) {
+        if(monthlyBudgets[0].budgets[currentMonth] !== 0) monthlyBudgetAmount = monthlyBudgets[0].budgets[currentMonth];
+    }
     let progress = (totalExpenses / monthlyBudgetAmount) * 100;
     progress > 100 ? progress = 100 : progress = progress;
 
@@ -63,12 +66,13 @@ const Calendar = () => {
         if (input !== null) {
             const budget = parseFloat(input);
             if (!isNaN(budget)) {
-                if (monthlyBudget.length < 1) {
-                    addMonthlyBudget(budget); 
-                    toast.success("Budget added successfully.");
+                if (monthlyBudgets.length < 1) {
+                    createMonthlyBudgets(budget, currentMonth); 
+                    toast.success('Budget for ${currentMonth} added successfully.')
                 } else {
-                    updateMonthlyBudget(budget); 
-                    toast.success("Budget updated successfully.");
+                    updateMonthlyBudgets(budget, currentMonth); 
+                    monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ${currentMonth} updated successfully.') :  toast.success('Budget for ${currentMonth} added successfully.');
+
                 }
             } else {
                 toast.error("Please enter a valid number for the monthly budget.");

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -29,8 +29,7 @@ const Calendar = () => {
     const [expectedExpenses, setExpectedExpenses] = useState({});
     const [daysWithData, setDaysWithData] = useState([]);
     const [removedEvents, setRemovedEvents] = useState({});
-    const [showMonthSelectorPanel, setShowMonthSelectorPanel] = useState(false);
-    const [shouldRenderCalendar, setShouldRenderCalendar] = useState(true);
+    const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December",];
 
     debugger;
     //Variables to calculate total income, total expenses, and the percentage of the total expenses compared to the monthly budget.
@@ -81,10 +80,10 @@ const Calendar = () => {
             if (!isNaN(budget)) {
                 if (monthlyBudgets.length < 1) {
                     createMonthlyBudgets(budget, currentMonth); 
-                    toast.success('Budget for' + currentMonth.toLocaleString() + 'added successfully.')
+                    toast.success('Budget for' + months[currentMonth] + 'added successfully.')
                 } else {
                     updateMonthlyBudgets(budget, currentMonth); 
-                    monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ' + currentMonth.toLocaleString() + ' updated successfully.') :  toast.success('Budget for ' + currentMonth.toLocaleString() + ' added successfully.');
+                    monthlyBudgets.budgets[currentMonth] !== 0 ? toast.success('Budget for ' + months[currentMonth] + ' updated successfully.') :  toast.success('Budget for ' + months[currentMonth] + ' added successfully.');
 
                 }
             } else {

--- a/src/app/Page-Functionality/Calendar.js
+++ b/src/app/Page-Functionality/Calendar.js
@@ -78,7 +78,7 @@ const Calendar = () => {
         if (input !== null) {
             const budget = parseFloat(input);
             if (!isNaN(budget)) {
-                if (monthlyBudgets.length < 1) {
+                if (monthlyBudgets.budgets.length < 0) {
                     createMonthlyBudgets(budget, currentMonth); 
                     toast.success('Budget for' + months[currentMonth] + 'added successfully.')
                 } else {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -245,17 +245,3 @@ body, button, input, .btn, .balance-box, .balance-label, .balance-amount, .text-
 .bg-custom-gray {
   background-color: rgb(28, 29, 33);
 }
-
-.budget-button {
-  display: block;
-  width: 300px;
-  text-align: center;
-  justify-content: center;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  margin-left: 420px;
-  background-color: rgb(150,150,150);
-  color: black;
-  border-radius: 10px;
-  padding: 10px 20px;
-}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -37,7 +37,7 @@ export default function Home() {
   const [showAddExpenseModal, setShowAddExpenseModal] = useState(false);
   const [showTableAnalisis, setShowTableAnalisis] = useState(false);
   const [balance, setBalance] = useState(0);
-  const { expenses, income, monthlyBudget, addMonthlyBudget, updateMonthlyBudget } = useContext(financeContext);
+  const { expenses, income } = useContext(financeContext);
 
   const { user } = useContext(authContext);
 
@@ -101,28 +101,6 @@ export default function Home() {
     }
   }
 
-  debugger;
-  /** Handles the budget button. Adds a budget to the database if the user does not already have one. 
-       * If the user has a budget, then it is updated.
-       * 
-       */
-  const handleAddOrUpdateBudget = () => {
-    const input = window.prompt("Enter the monthly budget:");
-    if (input !== null) {
-        const budget = parseFloat(input);
-        if (!isNaN(budget)) {
-            if (monthlyBudget.length < 1) {
-                addMonthlyBudget(budget); 
-                toast.success("Budget added successfully.");
-            } else {
-                updateMonthlyBudget(budget); 
-                toast.success("Budget updated successfully.");
-            }
-        } else {
-            toast.error("Please enter a valid number for the monthly budget.");
-        }
-    }
-  };
 
   const renderCurrentPage = () => {
     switch(currentPage) {
@@ -220,9 +198,6 @@ export default function Home() {
             {/* Calendar */}
             <section className='py-6 pl-6'>
               <h3 className='text-2xl text-center'>Calendar System</h3>
-              <div className='budget-button'>
-                <button onClick={handleAddOrUpdateBudget}>Add/Update Monthly Budget</button>
-              </div>
               <div className="flex justify-center">
                 <Calendar />
               </div>


### PR DESCRIPTION
Merged the branch from #256 , so that the progress bar and budget button remain in the same place. Turned the monthly budgets from a single budget into an array of multiple budgets, i.e. from `budget : 5000` to `budgets : [0,5000,0...]`. Made the monthly filters filter the expenses depending on the month selected in the calendar of the current year, and calculate and render the progress bar according to the budget (if available, if not then it is defaulted to 1) of that month. 
Closes #256 , #259 